### PR TITLE
Added a command to check if a word is phonotactically valid in Na'vi or not

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -489,5 +489,21 @@ async def list(inter, word=Param(description="Word to check for phonotactic vali
     await inter.response.send_message(get_validity(word))
 
 
+@fwew_bot.slash_command(name="oddballs", description="see which words bend or break Na'vi phonotactics")
+async def list(inter,
+                   ipa=Param(description="set to true to show IPA",
+                             default=False, choices=["true", "false"]),
+                   lang=Param(description="Language for results",
+                              default=None, choices=languages),
+                   reef=Param(description="Show reef dialect stuff",
+                          default=False, choices=["true", "false"])):
+    """
+    Take a word and determine whether or not it's phonotactically valid in Na'vi
+    """
+    if lang is None:
+        lang = get_language(inter)
+    await Paginator.Simple().start(inter, pages=get_oddballs(ipa, lang, reef))
+
+
 if __name__ == "__main__":
     fwew_bot.run(token)

--- a/bot.py
+++ b/bot.py
@@ -481,5 +481,19 @@ async def translate_message(inter, message):
     await inter.edit_original_message(content=get_translation(message.content, "en"))
 
 
+@fwew_bot.slash_command(name="valid", description="see if a possible Na'vi word is valid")
+async def list(inter, word=Param(description="Word to check for validity in Na'vi")):
+    """
+    list all words with certain characteristics
+
+    Parameters
+    ----------
+    where: characteristics of the word, such as part of speech, number of syllables, etc.
+    lang: the two-letter language-code for results (default: en)
+    check_digraphs: Should it pay attention to just the letters or what digraphs they represent, too?
+    """
+    await inter.response.send_message(get_validity(word))
+
+
 if __name__ == "__main__":
     fwew_bot.run(token)

--- a/bot.py
+++ b/bot.py
@@ -482,15 +482,9 @@ async def translate_message(inter, message):
 
 
 @fwew_bot.slash_command(name="valid", description="see if a possible Na'vi word is valid")
-async def list(inter, word=Param(description="Word to check for validity in Na'vi")):
+async def list(inter, word=Param(description="Word to check for phonotactic validity in Na'vi")):
     """
-    list all words with certain characteristics
-
-    Parameters
-    ----------
-    where: characteristics of the word, such as part of speech, number of syllables, etc.
-    lang: the two-letter language-code for results (default: en)
-    check_digraphs: Should it pay attention to just the letters or what digraphs they represent, too?
+    Take a word and determine whether or not it's phonotactically valid in Na'vi
     """
     await inter.response.send_message(get_validity(word))
 

--- a/lib.py
+++ b/lib.py
@@ -1180,6 +1180,14 @@ def get_cameron_words() -> str:
 - **Other:** eyk, irayo, makto, taron, te"""
 
 
+def get_validity(word: str) -> str:
+    res = requests.get(f"{api_url}/valid/{word}")
+    text = res.text
+    words2 = json.loads(text)
+
+    return words2
+
+
 def get_version() -> str:
     res = requests.get(f"{api_url}/version")
     return format_version(res.text)

--- a/lib.py
+++ b/lib.py
@@ -1188,6 +1188,39 @@ def get_validity(word: str) -> str:
     return words2
 
 
+def get_oddballs(showIPA: bool, languageCode: str, reef: bool) -> str:
+    embeds = []
+
+    res = requests.get(f"{api_url}/oddballs")
+    text = res.text
+    words2 = json.loads(text)
+    results, total = format_pages_dictionary(words2, languageCode, showIPA, reef)
+
+    # Create a list of embeds to paginate.
+    i = 0
+    firstResult = 0
+
+    hasWords = False
+
+    for a in results:
+        i += 1
+        lastResult = 0
+        for b in a.split("\n"):
+            if len(b) > 0 and b[0] == "[":
+                lastResult += 1
+                if not b.endswith("not found"):
+                    hasWords = True
+        embeds.append(disnake.Embed(color=Colour.blue(), title="Results " + str(firstResult + 1) + "-" +
+                      str(firstResult + lastResult) + " of " + str(total) + " (page " + str(i) + ")", description=a))
+        firstResult += lastResult
+
+    if not hasWords:
+        embeds = [disnake.Embed(color=Colour.orange(
+        ), title="No words found", description="No oddballs found:\n")]
+
+    return embeds
+
+
 def get_version() -> str:
     res = requests.get(f"{api_url}/version")
     return format_version(res.text)


### PR DESCRIPTION
- Added a `/valid` command to determine whether or not a word would be valid as a Na'vi word, including whether or not it looks like a reef dialect word and what is wrong with the word (if anything)
- Added an `/oddball` command to show all (3 of) the Na'vi words that seemingly violate Na'vi phonotactics (jakesully, oìsss, oìsss si)